### PR TITLE
WIP: Supports timedelta and seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```python
 from throttle_controller import SimpleThrottleController
 
-throttle = SimpleThrottleController(default_cooldown_time=3.0)
+throttle = SimpleThrottleController.create(default_cooldown_time=3.0)
 throttle.wait_if_needed("http://example.com/path/to/api")
 throttle.record_use_time_as_now("http://example.com/path/to/api")
 ... # requests

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -20,9 +20,14 @@ def test_throttling() -> None:
     point4 = datetime.datetime.now()
     throttle_controller.wait_if_needed("b")
     throttle_controller.record_use_time_as_now("b")
+    throttle_controller.set_cooldown_time("b", 2.0)
     point5 = datetime.datetime.now()
+    throttle_controller.wait_if_needed("b")
+    throttle_controller.record_use_time_as_now("b")
+    point6 = datetime.datetime.now()
 
     assert point2 - point1 <= alpha
     assert cooldown_time - alpha <= point3 - point2 <= cooldown_time + alpha
     assert cooldown_time - alpha <= point4 - point3 <= cooldown_time + alpha
     assert point5 - point4 <= alpha
+    assert point6 - point5 <= datetime.timedelta(seconds=2.0) + alpha

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -49,6 +49,9 @@ class SimpleThrottleController:
     def _has_ever_used(self, key: str) -> bool:
         return key in self.last_use_times
 
+    def set_cooldown_time(self, key: str, cooldown_time: Interval) -> None:
+        self.cooldown_times[key] = interval_to_timedelta(cooldown_time)
+
 
 if TYPE_CHECKING:
     _: Type[ThrottleController] = SimpleThrottleController

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -1,16 +1,24 @@
+from __future__ import annotations
+
 import datetime
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, Type
+from typing import TYPE_CHECKING, Dict, Optional, Type, Union
 
 from .protocol import ThrottleController
+
+Interval = Union[datetime.timedelta, float, int]
 
 
 @dataclass
 class SimpleThrottleController:
-    default_cooldown_time: datetime.timedelta = datetime.timedelta(seconds=3.0)
+    default_cooldown_time: datetime.timedelta
     last_use_times: Dict[str, datetime.datetime] = field(default_factory=dict)
     cooldown_times: Dict[str, datetime.timedelta] = field(default_factory=dict)
+
+    @classmethod
+    def create(cls, *, default_cooldown_time: Interval) -> SimpleThrottleController:
+        return cls(default_cooldown_time=interval_to_timedelta(default_cooldown_time))
 
     def cooldown_time_for(self, key: str) -> datetime.timedelta:
         return self.cooldown_times.get(key, self.default_cooldown_time)
@@ -44,3 +52,11 @@ class SimpleThrottleController:
 
 if TYPE_CHECKING:
     _: Type[ThrottleController] = SimpleThrottleController
+
+
+def interval_to_timedelta(interval: Optional[Interval]) -> datetime.timedelta:
+    if interval is None:
+        return datetime.timedelta(0)
+    if isinstance(interval, datetime.timedelta):
+        return interval
+    return datetime.timedelta(seconds=interval)


### PR DESCRIPTION
Currently, following code makes problem. default_cooldown_time only accepts datetime.timedelta.
```python
throttle = SimpleThrottleController(default_cooldown_time=3.0)
```

Define `create` factory classmethod. This accepts datetime.timedelta, float and int.

```python
throttle = SimpleThrottleController.create(default_cooldown_time=3.0)
```