### PR TITLE
Coverage Correction

### DIFF
--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -6,7 +6,7 @@ from typing import Generator, Hashable
 if sys.version_info >= (3, 8):
     from typing import Protocol
 else:
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # pragma: no cover
 
 
 Key = Hashable


### PR DESCRIPTION
When using `from typing_extensions import Protocol` instead of `from typing import Protocol` because Python 3.7 or earlier does not support it, there is no need to include it in the coverage measurement, so add a `no cover` comment.
By adding the `no cover` comment, you can exclude it from the coverage measurement.
