### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,34 @@ ignore_missing_imports = false
 
 [tool.ruff]
 line-length = 79
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S101",
+]

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -36,7 +36,9 @@ def test_throttling() -> None:
 def test_with_statement() -> None:
     alpha = datetime.timedelta(seconds=0.01)
     cooldown_time = datetime.timedelta(seconds=1.0)
-    throttle = SimpleThrottleController.create(default_cooldown_time=cooldown_time)
+    throttle = SimpleThrottleController.create(
+        default_cooldown_time=cooldown_time,
+    )
 
     point1 = datetime.datetime.now()
     with throttle.use("a"):

--- a/tests/test_utils_interval.py
+++ b/tests/test_utils_interval.py
@@ -7,6 +7,6 @@ def test_interval_to_timedelta() -> None:
     assert interval_to_timedelta(None) == datetime.timedelta(0)
     assert interval_to_timedelta(1) == datetime.timedelta(seconds=1)
     assert interval_to_timedelta(1.0) == datetime.timedelta(seconds=1)
-    assert interval_to_timedelta(datetime.timedelta(seconds=1)) == datetime.timedelta(
-        seconds=1
-    )
+    assert interval_to_timedelta(
+        datetime.timedelta(seconds=1),
+    ) == datetime.timedelta(seconds=1)

--- a/throttle_controller/__init__.py
+++ b/throttle_controller/__init__.py
@@ -1,7 +1,6 @@
+# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+from ._version import __version__
 from .protocol import ThrottleController
 from .simple import SimpleThrottleController
 
-# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
-from ._version import __version__
-
-__all__ = ["ThrottleController", "SimpleThrottleController", "__version__"]
+__all__ = ["SimpleThrottleController", "ThrottleController", "__version__"]

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -1,13 +1,7 @@
 import contextlib
 import datetime
-import sys
-from typing import Generator, Hashable
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol  # pragma: no cover
-
+from collections.abc import Generator, Hashable
+from typing import Protocol  # pragma: no cover
 
 Key = Hashable
 
@@ -16,7 +10,7 @@ class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime
+        self, key: Key, use_time: datetime.datetime,
     ) -> None: ...
 
     def record_use_time_as_now(self, key: Key) -> None: ...

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -16,10 +16,10 @@ class SimpleThrottleController(ThrottleController):
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval
+        cls, *, default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
         return cls(
-            default_cooldown_time=interval_to_timedelta(default_cooldown_time)
+            default_cooldown_time=interval_to_timedelta(default_cooldown_time),
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import datetime
-from typing import Optional, Union
 
-Interval = Union[datetime.timedelta, float, int]
+Interval = datetime.timedelta | float | int
 
 
-def interval_to_timedelta(interval: Optional[Interval]) -> datetime.timedelta:
+def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:
     if interval is None:
         return datetime.timedelta(seconds=0)
     if isinstance(interval, datetime.timedelta):


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
