### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,4 +104,4 @@ select = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 3
+max-complexity = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,6 @@ select = [
     "D",
     "S101",
 ]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 3

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -6,8 +6,7 @@ Interval = datetime.timedelta | float | int
 
 
 def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:
-    if interval is None:
-        return datetime.timedelta(seconds=0)
     if isinstance(interval, datetime.timedelta):
         return interval
-    return datetime.timedelta(seconds=interval)
+    seconds = 0 if interval is None else interval
+    return datetime.timedelta(seconds=seconds)


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 3`
- lower the limit to `2`
- simplify interval normalization without changing accepted input types

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- `uv run poe build` currently fails because `build` is not installed in the project environment