### PR TITLE
Fix Python version check in CI

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           actual_version=$(uv run python --version)
           expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          if [[ "$actual_version" != *"$expected_version"* ]]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi
@@ -50,4 +50,3 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
-


### PR DESCRIPTION
## Summary

- Invert the Python version check so it fails only on mismatches.

## Verification

- Parsed `.github/workflows/python-test.yml` as YAML.
- Ran `git diff --check`.
