### PR TITLE
ci: add permissions to publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,11 +7,16 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 env:
   python_version: 3.13
 
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What changed
- Add explicit workflow/job permissions to `Packaging` workflow to constrain scope when publish workflow runs.
- `contents` is set to `read` at workflow and `deploy` job level.

## Validation
- `uv sync`
- `uv run poe check`
- `uv run poe test` (fails in existing test suite: timing-sensitive throttling assertions)
- `uv run poe build`

## Notes
- No behavior change to publish logic; this is permission-boundary hardening only.
- The test failures are pre-existing and unrelated to this workflow change.
