### PR TITLE
Pin write workflow refs

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -8,4 +8,4 @@ permissions:
   pull-requests: write
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@a7071a4635eaece62696cd7132306616ce283c47

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@a7071a4635eaece62696cd7132306616ce283c47


### PR DESCRIPTION
## Summary
- Pin write-capable shared reusable workflow references to a specific commit SHA.
- Cover the gitignore update workflow and happy-commit workflow while keeping their existing permissions unchanged.

## Validation
- git diff --check
- actionlint .github/workflows/gitignore-in.yml .github/workflows/happy.yml .github/workflows/spellcheck.yml .github/workflows/python-test.yml .github/workflows/pypi-publish.yml .github/workflows/octocov.yml
