### PR TITLE
ci: cache uv dependencies in workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -30,6 +30,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- enable `astral-sh/setup-uv` caching in workflows that run `uv sync`
- key the dependency cache from `uv.lock`

## Verification
- `actionlint`
- `git diff --check`
- `uv sync`
- `uv run poe check`
- `uv run ruff check .`
- `uv build`
- Linux Docker: `uv run poe test`
- Linux Docker: `uv run poe coverage-xml`
