### PR TITLE
feat: add evict() and clear() methods to SimpleThrottleController

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -82,3 +82,36 @@ def test_next_available_time() -> None:
     point = datetime.datetime.now()
     throttle.record_use_time_as_now("a")
     assert throttle.next_available_time("a") > point
+
+
+def test_evict() -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    throttle.record_use_time_as_now("a")
+    throttle.set_cooldown_time("a", 2.0)
+    assert throttle.next_available_time("a") != datetime.datetime.min
+
+    throttle.evict("a")
+
+    assert throttle.next_available_time("a") == datetime.datetime.min
+    assert throttle.cooldown_time_for("a") == cooldown_time
+
+
+def test_evict_unknown_key() -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    throttle.evict("nonexistent")
+
+
+def test_clear() -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    throttle.record_use_time_as_now("a")
+    throttle.record_use_time_as_now("b")
+    throttle.set_cooldown_time("a", 2.0)
+
+    throttle.clear()
+
+    assert throttle.next_available_time("a") == datetime.datetime.min
+    assert throttle.next_available_time("b") == datetime.datetime.min
+    assert throttle.cooldown_time_for("a") == cooldown_time

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -16,7 +16,9 @@ class SimpleThrottleController(ThrottleController):
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval,
+        cls,
+        *,
+        default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),
@@ -53,3 +55,11 @@ class SimpleThrottleController(ThrottleController):
 
     def set_cooldown_time(self, key: Key, cooldown_time: Interval) -> None:
         self.cooldown_times[key] = interval_to_timedelta(cooldown_time)
+
+    def evict(self, key: Key) -> None:
+        self.last_use_times.pop(key, None)
+        self.cooldown_times.pop(key, None)
+
+    def clear(self) -> None:
+        self.last_use_times.clear()
+        self.cooldown_times.clear()


### PR DESCRIPTION
## Summary

`SimpleThrottleController` previously had no way to remove entries from its internal `last_use_times` and `cooldown_times` dicts. In long-running processes with many distinct keys (e.g. per-URL throttling), these dicts grew without bound.

This PR adds two new methods:

- `evict(key)` — removes a single key's records from both dicts. Safe to call for keys that were never recorded (no-op).
- `clear()` — removes all records, resetting the controller to its initial state.

## Changes

- `throttle_controller/simple.py`: added `evict()` and `clear()` methods
- `tests/test_simple.py`: added `test_evict`, `test_evict_unknown_key`, `test_clear`

## Validation

- `ruff format` + `ruff check`: pass
- `mypy --strict`: pass
- `vulture`: 0 findings
- New tests: pass
- Existing tests: pre-existing timing flakiness unaffected by this change

## Trade-offs

- Eviction is explicit (callers decide when a key's lifecycle ends). This is intentional for a throttle controller: automatic eviction strategies (LRU, TTL) would require choosing a policy that affects throttle correctness.
