### PR TITLE
docs: document start-to-start cooldown behaviour and end-to-start alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@ This package is currently in **Alpha** (`Development Status :: 3 - Alpha`).
 - The package will be considered for Beta promotion when thread-safe and multi-process support is implemented.
 - A stable (1.0) release is planned after Beta validation.
 
+## Cooldown timing behaviour
+
+The `use()` context manager and the manual `record_use_time_as_now()` call record
+the **start** of each use, not the end. This means the cooldown is measured
+**start-to-start**: the next call may proceed once `cooldown_time` has elapsed
+since the *start* of the previous call.
+
+```
+call 1 start ──────────── call 1 body (2.9 s) ────── call 1 end
+             │
+             └── cooldown_time = 3.0 s ──────────────────────────► call 2 may start
+                                                               (only 0.1 s after call 1 ends)
+```
+
+If you need **end-to-start** behaviour (next call waits until at least
+`cooldown_time` after the *previous call finishes*), record the time after your
+work completes instead of relying on the context manager:
+
+```python
+throttle.wait_if_needed(key)
+result = do_work()          # your code here
+throttle.record_use_time_as_now(key)   # record end of work
+```
+
 # Caution
 
 Currently this package supports only to use in single thread / single process use-cases.


### PR DESCRIPTION
## Summary

`SimpleThrottleController.use()` records the use time at the **start** of each call (before `yield`), giving start-to-start cooldown semantics. When a call body takes a long time, the effective wait until the next call is shorter than `cooldown_time`.

This behaviour was not documented. This PR adds a section to the README explaining the difference between start-to-start and end-to-start cooldown, and shows how to achieve end-to-start semantics with the existing API.

## Changes

- `README.md`: added **Cooldown timing behaviour** section with ASCII diagram and end-to-start workaround example

## Validation

- `ruff format` + `ruff check`: pass
- `mypy --strict`: pass
- `vulture`: 0 findings
- No behavioural changes; documentation only

## Trade-offs

- No code change — the default remains start-to-start. Changing the default would be a breaking change.
- Users needing end-to-start can achieve it by calling `record_use_time_as_now()` after their work completes, as shown in the new README section.
