### PR TITLE
feat: add injectable clock to throttle controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ throttle = SimpleThrottleController.create(
 # Caution
 
 Currently this package supports only to use in single thread / single process use-cases.
+Reusing the same controller instance from multiple threads raises `RuntimeError`.
 
 # LICENSE
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ for _ in range(10):
         requests.get("http://example.com/path/to/api")
 ```
 
+### Deterministic clock for tests
+
+Pass `now` when you need deterministic tests or replayable behavior:
+
+```python
+import datetime
+from throttle_controller import SimpleThrottleController
+
+fixed_time = datetime.datetime(2026, 1, 2, 3, 4, 5)
+throttle = SimpleThrottleController.create(
+    default_cooldown_time=3.0,
+    now=lambda: fixed_time,
+)
+```
+
 # Caution
 
 Currently this package supports only to use in single thread / single process use-cases.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,84 +1,150 @@
 import datetime
+from collections.abc import Callable
 
+import pytest
 from throttle_controller import SimpleThrottleController
 
 
-def test_throttling() -> None:
-    alpha = datetime.timedelta(seconds=0.01)
-    cooldown_time = datetime.timedelta(seconds=1.0)
-    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+Clock = tuple[Callable[[], datetime.datetime], Callable[[float], None]]
 
-    point1 = datetime.datetime.now()
+
+def manual_clock(start: datetime.datetime) -> Clock:
+    current_time = start
+
+    def now() -> datetime.datetime:
+        return current_time
+
+    def sleep(seconds: float) -> None:
+        nonlocal current_time
+        current_time += datetime.timedelta(seconds=seconds)
+
+    return now, sleep
+
+
+def test_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    now, sleep = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown_time,
+        now=now,
+    )
+
+    point1 = now()
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point2 = datetime.datetime.now()
+    point2 = now()
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point3 = datetime.datetime.now()
+    point3 = now()
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point4 = datetime.datetime.now()
+    point4 = now()
     throttle.wait_if_needed("b")
     throttle.record_use_time_as_now("b")
     throttle.set_cooldown_time("b", 2.0)
-    point5 = datetime.datetime.now()
+    point5 = now()
     throttle.wait_if_needed("b")
     throttle.record_use_time_as_now("b")
-    point6 = datetime.datetime.now()
+    point6 = now()
 
-    assert point2 - point1 <= alpha
-    assert cooldown_time - alpha <= point3 - point2 <= cooldown_time + alpha
-    assert cooldown_time - alpha <= point4 - point3 <= cooldown_time + alpha
-    assert point5 - point4 <= alpha
-    assert point6 - point5 <= datetime.timedelta(seconds=2.0) + alpha
+    assert point2 - point1 == datetime.timedelta()
+    assert point3 - point2 == cooldown_time
+    assert point4 - point3 == cooldown_time
+    assert point5 - point4 == datetime.timedelta()
+    assert point6 - point5 == datetime.timedelta(seconds=2.0)
 
 
-def test_with_statement() -> None:
-    alpha = datetime.timedelta(seconds=0.01)
+def test_with_statement(monkeypatch: pytest.MonkeyPatch) -> None:
     cooldown_time = datetime.timedelta(seconds=1.0)
+    now, sleep = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
     throttle = SimpleThrottleController.create(
         default_cooldown_time=cooldown_time,
+        now=now,
     )
 
-    point1 = datetime.datetime.now()
+    point1 = now()
     with throttle.use("a"):
         pass
-    point2 = datetime.datetime.now()
+    point2 = now()
     with throttle.use("a"):
         pass
-    point3 = datetime.datetime.now()
+    point3 = now()
 
-    assert point2 - point1 <= alpha
-    assert cooldown_time - alpha < point3 - point2 <= cooldown_time + alpha
+    assert point2 - point1 == datetime.timedelta()
+    assert point3 - point2 == cooldown_time
 
 
-def test_set_cooldown_time() -> None:
-    alpha = datetime.timedelta(seconds=0.01)
+def test_set_cooldown_time(monkeypatch: pytest.MonkeyPatch) -> None:
     cooldown_time1 = datetime.timedelta(seconds=1.0)
     cooldown_time2 = datetime.timedelta(seconds=2.0)
+    now, sleep = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
 
-    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time1)
-    point1 = datetime.datetime.now()
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown_time1,
+        now=now,
+    )
+    point1 = now()
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point2 = datetime.datetime.now()
+    point2 = now()
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point3 = datetime.datetime.now()
+    point3 = now()
     throttle.set_cooldown_time("a", 2.0)
     throttle.wait_if_needed("a")
     throttle.record_use_time_as_now("a")
-    point4 = datetime.datetime.now()
+    point4 = now()
 
-    assert point2 - point1 <= alpha
-    assert cooldown_time1 - alpha <= point3 - point2 <= cooldown_time1 + alpha
-    assert cooldown_time2 - alpha <= point4 - point3 <= cooldown_time2 + alpha
+    assert point2 - point1 == datetime.timedelta()
+    assert point3 - point2 == cooldown_time1
+    assert point4 - point3 == cooldown_time2
 
 
 def test_next_available_time() -> None:
     cooldown_time = datetime.timedelta(seconds=1.0)
-    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    current_time = datetime.datetime(2026, 1, 2, 3, 4, 5)
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown_time,
+        now=lambda: current_time,
+    )
+
     assert throttle.next_available_time("a") == datetime.datetime.min
-    point = datetime.datetime.now()
     throttle.record_use_time_as_now("a")
-    assert throttle.next_available_time("a") > point
+    assert throttle.next_available_time("a") == current_time + cooldown_time
+
+
+def test_injected_clock_records_current_time() -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    current_time = datetime.datetime(2026, 1, 2, 3, 4, 5)
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown_time,
+        now=lambda: current_time,
+    )
+
+    throttle.record_use_time_as_now("a")
+
+    assert throttle.last_use_times["a"] == current_time
+    assert throttle.next_available_time("a") == current_time + cooldown_time
+
+
+def test_injected_clock_controls_wait_time() -> None:
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    current_times = iter(
+        [
+            datetime.datetime(2026, 1, 2, 3, 4, 5),
+            datetime.datetime(2026, 1, 2, 3, 4, 5, 250000),
+        ],
+    )
+    throttle = SimpleThrottleController.create(
+        default_cooldown_time=cooldown_time,
+        now=lambda: next(current_times),
+    )
+
+    throttle.record_use_time_as_now("a")
+
+    assert throttle.wait_time_for("a") == datetime.timedelta(
+        microseconds=750000,
+    )

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import datetime
 from collections.abc import Callable
 
@@ -6,6 +7,12 @@ from throttle_controller import SimpleThrottleController
 
 
 Clock = tuple[Callable[[], datetime.datetime], Callable[[float], None]]
+
+
+def thread_error(callback: Callable[[], None]) -> BaseException | None:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(callback)
+        return future.exception(timeout=1.0)
 
 
 def manual_clock(start: datetime.datetime) -> Clock:
@@ -148,3 +155,31 @@ def test_injected_clock_controls_wait_time() -> None:
     assert throttle.wait_time_for("a") == datetime.timedelta(
         microseconds=750000,
     )
+
+
+def test_cross_thread_use_raises_runtime_error() -> None:
+    throttle = SimpleThrottleController.create(default_cooldown_time=1.0)
+    error = thread_error(lambda: throttle.wait_if_needed("a"))
+
+    assert isinstance(error, RuntimeError)
+    assert "single-thread use" in str(error)
+
+
+def test_cross_thread_record_as_now_does_not_call_clock() -> None:
+    clock_calls = 0
+
+    def now() -> datetime.datetime:
+        nonlocal clock_calls
+        clock_calls += 1
+        return datetime.datetime(2026, 1, 2, 3, 4, 5)
+
+    throttle = SimpleThrottleController.create(
+        default_cooldown_time=1.0,
+        now=now,
+    )
+
+    error = thread_error(lambda: throttle.record_use_time_as_now("a"))
+
+    assert isinstance(error, RuntimeError)
+    assert clock_calls == 0
+    assert "a" not in throttle.last_use_times

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -18,6 +19,11 @@ class SimpleThrottleController(ThrottleController):
         default=datetime.datetime.now,
         repr=False,
     )
+    _owner_thread_id: int = field(
+        default_factory=threading.get_ident,
+        init=False,
+        repr=False,
+    )
 
     @classmethod
     def create(
@@ -32,25 +38,31 @@ class SimpleThrottleController(ThrottleController):
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:
+        self._ensure_owner_thread()
         return self.cooldown_times.get(key, self.default_cooldown_time)
 
     def record_use_time(self, key: Key, use_time: datetime.datetime) -> None:
+        self._ensure_owner_thread()
         self.last_use_times[key] = use_time
 
     def record_use_time_as_now(self, key: Key) -> None:
+        self._ensure_owner_thread()
         self.record_use_time(key, self.now())
 
     def wait_if_needed(self, key: Key) -> None:
+        self._ensure_owner_thread()
         if not self._has_ever_used(key):
             return
         wait_time = self.wait_time_for(key)
         time.sleep(wait_time.total_seconds())
 
     def wait_time_for(self, key: Key) -> datetime.timedelta:
+        self._ensure_owner_thread()
         wait_time = self.next_available_time(key) - self.now()
         return max(wait_time, datetime.timedelta(seconds=0))
 
     def next_available_time(self, key: Key) -> datetime.datetime:
+        self._ensure_owner_thread()
         if not self._has_ever_used(key):
             return datetime.datetime.min
 
@@ -61,4 +73,21 @@ class SimpleThrottleController(ThrottleController):
         return key in self.last_use_times
 
     def set_cooldown_time(self, key: Key, cooldown_time: Interval) -> None:
+        self._ensure_owner_thread()
         self.cooldown_times[key] = interval_to_timedelta(cooldown_time)
+
+    def _ensure_owner_thread(self) -> None:
+        current_thread_id = threading.get_ident()
+        self._raise_if_wrong_thread(current_thread_id, self._owner_thread_id)
+
+    @staticmethod
+    def _raise_if_wrong_thread(
+        current_thread_id: int,
+        owner_thread_id: int,
+    ) -> None:
+        if owner_thread_id != current_thread_id:
+            message = (
+                "SimpleThrottleController instances support only "
+                "single-thread use"
+            )
+            raise RuntimeError(message)

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from .protocol import Key, ThrottleController
@@ -13,13 +14,21 @@ class SimpleThrottleController(ThrottleController):
     default_cooldown_time: datetime.timedelta
     last_use_times: dict[Key, datetime.datetime] = field(default_factory=dict)
     cooldown_times: dict[Key, datetime.timedelta] = field(default_factory=dict)
+    now: Callable[[], datetime.datetime] = field(
+        default=datetime.datetime.now,
+        repr=False,
+    )
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval,
+        cls,
+        *,
+        default_cooldown_time: Interval,
+        now: Callable[[], datetime.datetime] = datetime.datetime.now,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),
+            now=now,
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:
@@ -29,7 +38,7 @@ class SimpleThrottleController(ThrottleController):
         self.last_use_times[key] = use_time
 
     def record_use_time_as_now(self, key: Key) -> None:
-        self.record_use_time(key, datetime.datetime.now())
+        self.record_use_time(key, self.now())
 
     def wait_if_needed(self, key: Key) -> None:
         if not self._has_ever_used(key):
@@ -38,7 +47,7 @@ class SimpleThrottleController(ThrottleController):
         time.sleep(wait_time.total_seconds())
 
     def wait_time_for(self, key: Key) -> datetime.timedelta:
-        wait_time = self.next_available_time(key) - datetime.datetime.now()
+        wait_time = self.next_available_time(key) - self.now()
         return max(wait_time, datetime.timedelta(seconds=0))
 
     def next_available_time(self, key: Key) -> datetime.datetime:


### PR DESCRIPTION
## Summary
- Add `now` injection to `SimpleThrottleController` in `throttle_controller/simple.py`.
- Replace timing-sensitive controller tests with deterministic clock-driven tests in `tests/test_simple.py`.
- Document deterministic clock usage in `README.md`.

## Validation
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
