### PR TITLE
fix: accept optional now parameter in wait_time_for for deterministic testing

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -115,3 +115,23 @@ def test_clear() -> None:
     assert throttle.next_available_time("a") == datetime.datetime.min
     assert throttle.next_available_time("b") == datetime.datetime.min
     assert throttle.cooldown_time_for("a") == cooldown_time
+
+
+def test_wait_time_for_with_injected_now() -> None:
+    cooldown_time = datetime.timedelta(seconds=10.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+
+    use_time = datetime.datetime(2020, 1, 1, 0, 0, 0)
+    throttle.record_use_time("a", use_time)
+
+    # 5 seconds after use: 5 seconds remain
+    now_mid = use_time + datetime.timedelta(seconds=5)
+    assert throttle.wait_time_for("a", now=now_mid) == datetime.timedelta(seconds=5)
+
+    # exactly at next available: 0 seconds remain
+    now_ready = use_time + datetime.timedelta(seconds=10)
+    assert throttle.wait_time_for("a", now=now_ready) == datetime.timedelta(seconds=0)
+
+    # past next available: clamped to 0
+    now_past = use_time + datetime.timedelta(seconds=15)
+    assert throttle.wait_time_for("a", now=now_past) == datetime.timedelta(seconds=0)

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -39,8 +39,14 @@ class SimpleThrottleController(ThrottleController):
         wait_time = self.wait_time_for(key)
         time.sleep(wait_time.total_seconds())
 
-    def wait_time_for(self, key: Key) -> datetime.timedelta:
-        wait_time = self.next_available_time(key) - datetime.datetime.now()
+    def wait_time_for(
+        self,
+        key: Key,
+        now: datetime.datetime | None = None,
+    ) -> datetime.timedelta:
+        if now is None:
+            now = datetime.datetime.now()
+        wait_time = self.next_available_time(key) - now
         return max(wait_time, datetime.timedelta(seconds=0))
 
     def next_available_time(self, key: Key) -> datetime.datetime:


### PR DESCRIPTION
## Summary

`wait_time_for` computed remaining wait time using `datetime.datetime.now()`
directly, making it impossible to test the logic deterministically — test
outcomes varied with system load and call timing.

## Change

Add an optional `now: datetime.datetime | None = None` parameter to
`wait_time_for`. When omitted the method falls back to `datetime.datetime.now()`,
preserving existing behaviour. Callers can now inject a fixed timestamp for
unit testing.

Also add `test_wait_time_for_with_injected_now` which verifies the remaining-
wait / ready / past-deadline cases without any `time.sleep`.

## Verification

- `uv run poe check` (ruff + mypy): all checks passed
- `uv run pytest`: 6/6 tests passed