### PR TITLE
fix: fail fast on cross-thread controller use

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ throttle = SimpleThrottleController.create(
 # Caution
 
 Currently this package supports only to use in single thread / single process use-cases.
+Reusing the same controller instance from multiple threads raises `RuntimeError`.
 
 # LICENSE
 

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import datetime
 from collections.abc import Callable
 
@@ -6,6 +7,12 @@ from throttle_controller import SimpleThrottleController
 
 
 Clock = tuple[Callable[[], datetime.datetime], Callable[[float], None]]
+
+
+def thread_error(callback: Callable[[], None]) -> BaseException | None:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(callback)
+        return future.exception(timeout=1.0)
 
 
 def manual_clock(start: datetime.datetime) -> Clock:
@@ -148,3 +155,31 @@ def test_injected_clock_controls_wait_time() -> None:
     assert throttle.wait_time_for("a") == datetime.timedelta(
         microseconds=750000,
     )
+
+
+def test_cross_thread_use_raises_runtime_error() -> None:
+    throttle = SimpleThrottleController.create(default_cooldown_time=1.0)
+    error = thread_error(lambda: throttle.wait_if_needed("a"))
+
+    assert isinstance(error, RuntimeError)
+    assert "single-thread use" in str(error)
+
+
+def test_cross_thread_record_as_now_does_not_call_clock() -> None:
+    clock_calls = 0
+
+    def now() -> datetime.datetime:
+        nonlocal clock_calls
+        clock_calls += 1
+        return datetime.datetime(2026, 1, 2, 3, 4, 5)
+
+    throttle = SimpleThrottleController.create(
+        default_cooldown_time=1.0,
+        now=now,
+    )
+
+    error = thread_error(lambda: throttle.record_use_time_as_now("a"))
+
+    assert isinstance(error, RuntimeError)
+    assert clock_calls == 0
+    assert "a" not in throttle.last_use_times

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -18,6 +19,11 @@ class SimpleThrottleController(ThrottleController):
         default=datetime.datetime.now,
         repr=False,
     )
+    _owner_thread_id: int = field(
+        default_factory=threading.get_ident,
+        init=False,
+        repr=False,
+    )
 
     @classmethod
     def create(
@@ -32,25 +38,31 @@ class SimpleThrottleController(ThrottleController):
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:
+        self._ensure_owner_thread()
         return self.cooldown_times.get(key, self.default_cooldown_time)
 
     def record_use_time(self, key: Key, use_time: datetime.datetime) -> None:
+        self._ensure_owner_thread()
         self.last_use_times[key] = use_time
 
     def record_use_time_as_now(self, key: Key) -> None:
+        self._ensure_owner_thread()
         self.record_use_time(key, self.now())
 
     def wait_if_needed(self, key: Key) -> None:
+        self._ensure_owner_thread()
         if not self._has_ever_used(key):
             return
         wait_time = self.wait_time_for(key)
         time.sleep(wait_time.total_seconds())
 
     def wait_time_for(self, key: Key) -> datetime.timedelta:
+        self._ensure_owner_thread()
         wait_time = self.next_available_time(key) - self.now()
         return max(wait_time, datetime.timedelta(seconds=0))
 
     def next_available_time(self, key: Key) -> datetime.datetime:
+        self._ensure_owner_thread()
         if not self._has_ever_used(key):
             return datetime.datetime.min
 
@@ -61,4 +73,21 @@ class SimpleThrottleController(ThrottleController):
         return key in self.last_use_times
 
     def set_cooldown_time(self, key: Key, cooldown_time: Interval) -> None:
+        self._ensure_owner_thread()
         self.cooldown_times[key] = interval_to_timedelta(cooldown_time)
+
+    def _ensure_owner_thread(self) -> None:
+        current_thread_id = threading.get_ident()
+        self._raise_if_wrong_thread(current_thread_id, self._owner_thread_id)
+
+    @staticmethod
+    def _raise_if_wrong_thread(
+        current_thread_id: int,
+        owner_thread_id: int,
+    ) -> None:
+        if owner_thread_id != current_thread_id:
+            message = (
+                "SimpleThrottleController instances support only "
+                "single-thread use"
+            )
+            raise RuntimeError(message)


### PR DESCRIPTION
## Summary
- Bind each `SimpleThrottleController` instance to its construction thread and reject calls from other threads.
- Check thread ownership before recording current time so wrong-thread calls do not run the injected clock.
- Document the runtime guard and add regression tests for cross-thread misuse.

## Validation
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`

## Notes
- This PR is stacked on #351 so the new concurrency guard tests run on deterministic clock-driven tests.
