### PR TITLE
refactor: replace write_to _version.py with importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-write_to = "throttle_controller/_version.py"
 version_scheme = "only-version"
 local_scheme = "no-local-version"
 

--- a/throttle_controller/__init__.py
+++ b/throttle_controller/__init__.py
@@ -1,6 +1,7 @@
-# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
-from ._version import __version__
+from importlib.metadata import version
+
 from .protocol import ThrottleController
 from .simple import SimpleThrottleController
 
+__version__ = version("throttle-controller")
 __all__ = ["SimpleThrottleController", "ThrottleController", "__version__"]


### PR DESCRIPTION
## Summary

- Remove `write_to = "throttle_controller/_version.py"` from the
  `[tool.setuptools_scm]` configuration in `pyproject.toml`
- Replace `from ._version import __version__` in `__init__.py` with
  `importlib.metadata.version("throttle-controller")`

## Motivation

`setuptools_scm` with `write_to` generates `_version.py` at every build
with an embedded commit hash (`__commit_id__ = 'g7212daf00'`).  This
file's content differs across environments for the same tagged release
(e.g., local dev vs. CI builds without git history).  While the file is
already listed in `.gitignore`, the `write_to` option causes it to be
regenerated on every `uv sync` or build invocation, making the working
tree non-deterministic.

## Solution

`importlib.metadata.version()` is the standard way to read a package
version at runtime.  The version is set once during `uv build` / `uv
publish` from the git tag via setuptools_scm, recorded in the wheel or
sdist metadata, and stays fixed for that release.  No source-tree file
needs to be generated or imported.

## Verification

- `uv sync && uv run python -c "from throttle_controller import __version__; print(__version__)"` → `0.3.1`
- `uv run poe check` (ruff + mypy) is clean
- `uv run poe test` passes
