### PR TITLE
Add IntervalSeconds type alias to make float/int interval unit explicit

### DIFF
--- a/tests/test_utils_interval.py
+++ b/tests/test_utils_interval.py
@@ -1,6 +1,6 @@
 import datetime
 
-from throttle_controller.utils.interval import interval_to_timedelta
+from throttle_controller.utils.interval import IntervalSeconds, interval_to_timedelta
 
 
 def test_interval_to_timedelta() -> None:
@@ -10,3 +10,10 @@ def test_interval_to_timedelta() -> None:
     assert interval_to_timedelta(
         datetime.timedelta(seconds=1),
     ) == datetime.timedelta(seconds=1)
+
+
+def test_interval_seconds_type_is_float_or_int() -> None:
+    seconds: IntervalSeconds = 2.5
+    assert interval_to_timedelta(seconds) == datetime.timedelta(seconds=2.5)
+    whole: IntervalSeconds = 3
+    assert interval_to_timedelta(whole) == datetime.timedelta(seconds=3)

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import datetime
 
-Interval = datetime.timedelta | float | int
+IntervalSeconds = float | int
+Interval = datetime.timedelta | IntervalSeconds
 
 
 def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:


### PR DESCRIPTION
## Summary

The `Interval = datetime.timedelta | float | int` type alias accepted plain
numbers but nothing in the name or signature indicated their unit. Callers
had to read `interval_to_timedelta` implementation to learn that `2.0` means
2 seconds, not milliseconds.

Add `IntervalSeconds = float | int` as a named type alias that encodes the
unit. `Interval` is redefined as `datetime.timedelta | IntervalSeconds`, so
existing code compiles unchanged while callers who want explicit unit
annotation can now write `IntervalSeconds` in their own type hints.

## Changes

- `throttle_controller/utils/interval.py`: add `IntervalSeconds = float | int`;
  redefine `Interval = datetime.timedelta | IntervalSeconds`
- `tests/test_utils_interval.py`: add test importing and using `IntervalSeconds`

## Test plan

- [x] `test_interval_seconds_type_is_float_or_int`: `IntervalSeconds` is
  importable and accepted by `interval_to_timedelta`
- [x] All 6 existing tests pass unchanged