### PR TITLE
Reject timezone-aware datetime in record_use_time to fail fast

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from throttle_controller import SimpleThrottleController
 
 
@@ -82,3 +84,11 @@ def test_next_available_time() -> None:
     point = datetime.datetime.now()
     throttle.record_use_time_as_now("a")
     assert throttle.next_available_time("a") > point
+
+
+def test_record_use_time_rejects_tz_aware() -> None:
+    cooldown = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown)
+    aware = datetime.datetime.now(tz=datetime.timezone.utc)
+    with pytest.raises(ValueError, match="timezone-naive"):
+        throttle.record_use_time("a", aware)

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -10,7 +10,9 @@ class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime,
+        self,
+        key: Key,
+        use_time: datetime.datetime,
     ) -> None: ...
 
     def record_use_time_as_now(self, key: Key) -> None: ...

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -16,7 +16,9 @@ class SimpleThrottleController(ThrottleController):
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval,
+        cls,
+        *,
+        default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),
@@ -26,6 +28,11 @@ class SimpleThrottleController(ThrottleController):
         return self.cooldown_times.get(key, self.default_cooldown_time)
 
     def record_use_time(self, key: Key, use_time: datetime.datetime) -> None:
+        if use_time.tzinfo is not None:
+            raise ValueError(
+                f"record_use_time requires a timezone-naive datetime, "
+                f"got timezone-aware datetime with tzinfo={use_time.tzinfo!r}",
+            )
         self.last_use_times[key] = use_time
 
     def record_use_time_as_now(self, key: Key) -> None:


### PR DESCRIPTION
## Summary

`record_use_time` accepted timezone-aware `datetime.datetime` objects, but
`wait_time_for` subtracted `datetime.datetime.now()` (timezone-naive) from the
stored value. This caused a `TypeError: can't subtract offset-naive and
offset-aware datetimes` at wait time rather than at record time, making the
root cause hard to locate.

## Changes

- `throttle_controller/simple.py`: Add a `tzinfo` check in `record_use_time`.
  If the caller passes a timezone-aware datetime, `ValueError` is raised
  immediately at the record site.
- `tests/test_simple.py`: Add `test_record_use_time_rejects_tz_aware` to cover
  the new validation.
- `throttle_controller/protocol.py`: Formatter reformatted the `record_use_time`
  signature (no logic change).

## Validation

- `uv run poe format` — reformatted
- `uv run poe check` — all checks pass
- `uv run pytest` — all new/changed tests pass
  (pre-existing `test_throttling` timing flakiness is unrelated to this change)

## Trade-offs

This is a surface fix: callers using timezone-aware datetimes will now get an
explicit `ValueError` instead of a `TypeError` later. Callers that need
timezone-aware support should normalize to naive UTC before calling
`record_use_time`, or wait for a future structural fix.
