### PR TITLE
Add max_wait field to SimpleThrottleController to bound sleep duration

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from throttle_controller import SimpleThrottleController
 
 
@@ -115,3 +117,33 @@ def test_clear() -> None:
     assert throttle.next_available_time("a") == datetime.datetime.min
     assert throttle.next_available_time("b") == datetime.datetime.min
     assert throttle.cooldown_time_for("a") == cooldown_time
+
+
+def test_max_wait_raises_timeout_error() -> None:
+    cooldown = datetime.timedelta(seconds=10.0)
+    max_wait = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown,
+        max_wait=max_wait,
+    )
+    past = datetime.datetime.now() - datetime.timedelta(seconds=5.0)
+    throttle.record_use_time("a", past)
+    with pytest.raises(TimeoutError):
+        throttle.wait_if_needed("a")
+
+
+def test_max_wait_via_create() -> None:
+    throttle = SimpleThrottleController.create(
+        default_cooldown_time=10.0,
+        max_wait=1.0,
+    )
+    assert throttle.max_wait == datetime.timedelta(seconds=1.0)
+
+
+def test_max_wait_none_allows_unlimited_wait() -> None:
+    throttle = SimpleThrottleController(
+        default_cooldown_time=datetime.timedelta(seconds=0.0),
+    )
+    assert throttle.max_wait is None
+    throttle.record_use_time_as_now("a")
+    throttle.wait_if_needed("a")

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -13,15 +13,20 @@ class SimpleThrottleController(ThrottleController):
     default_cooldown_time: datetime.timedelta
     last_use_times: dict[Key, datetime.datetime] = field(default_factory=dict)
     cooldown_times: dict[Key, datetime.timedelta] = field(default_factory=dict)
+    max_wait: datetime.timedelta | None = None
 
     @classmethod
     def create(
         cls,
         *,
         default_cooldown_time: Interval,
+        max_wait: Interval | None = None,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),
+            max_wait=interval_to_timedelta(max_wait)
+            if max_wait is not None
+            else None,
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:
@@ -37,7 +42,14 @@ class SimpleThrottleController(ThrottleController):
         if not self._has_ever_used(key):
             return
         wait_time = self.wait_time_for(key)
+        self._enforce_max_wait(wait_time)
         time.sleep(wait_time.total_seconds())
+
+    def _enforce_max_wait(self, wait_time: datetime.timedelta) -> None:
+        if self.max_wait is not None and wait_time > self.max_wait:
+            raise TimeoutError(
+                f"wait time {wait_time} exceeds max_wait {self.max_wait}",
+            )
 
     def wait_time_for(self, key: Key) -> datetime.timedelta:
         wait_time = self.next_available_time(key) - datetime.datetime.now()


### PR DESCRIPTION
## Summary

`wait_if_needed` calls `time.sleep` without any upper bound. Passing an extreme
`default_cooldown_time` (e.g. `datetime.timedelta.max`) or recording a
far-future use time causes the calling thread to block indefinitely with no way
to abort.

## Changes

- `throttle_controller/simple.py`: Add optional `max_wait: datetime.timedelta | None`
  field to `SimpleThrottleController` (default `None` = no limit). When the
  computed wait time exceeds `max_wait`, `wait_if_needed` raises `TimeoutError`
  before sleeping. Extracted the check into `_enforce_max_wait` to satisfy the
  cyclomatic-complexity limit.
- `throttle_controller/simple.py`: Expose `max_wait` through the `create()`
  factory method so callers using float/int intervals can set the limit without
  constructing a `timedelta` manually.
- `tests/test_simple.py`: Add three new tests covering the `TimeoutError` path,
  the `create()` factory, and the default unbounded behaviour.

## Validation

- `uv run poe format` — reformatted
- `uv run poe check` — all checks pass (ruff + mypy)
- `uv run pytest` — all new/changed tests pass
  (pre-existing `test_throttling` timing flakiness is unrelated to this change)

## Trade-offs

`max_wait` is set at construction time, so it applies uniformly to all keys.
Per-key limits would require a different API shape. The default `None` preserves
the existing unbounded behaviour, so existing callers are unaffected.
