### PR TITLE
feat: add to_dict/from_dict for state serialization

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -115,3 +115,54 @@ def test_clear() -> None:
     assert throttle.next_available_time("a") == datetime.datetime.min
     assert throttle.next_available_time("b") == datetime.datetime.min
     assert throttle.cooldown_time_for("a") == cooldown_time
+
+
+def test_to_dict_from_dict_round_trip() -> None:
+    cooldown_time = datetime.timedelta(seconds=5.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    use_time = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    throttle.record_use_time("api", use_time)
+    throttle.set_cooldown_time("api", 10.0)
+
+    data = throttle.to_dict()
+    restored = SimpleThrottleController.from_dict(data)
+
+    assert restored.default_cooldown_time == cooldown_time
+    assert restored.last_use_times == {"api": use_time}
+    assert restored.cooldown_times == {"api": datetime.timedelta(seconds=10.0)}
+    assert restored.next_available_time("api") == throttle.next_available_time(
+        "api",
+    )
+
+
+def test_to_dict_empty_state() -> None:
+    cooldown_time = datetime.timedelta(seconds=3.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    data = throttle.to_dict()
+
+    assert data["default_cooldown_time"] == 3.0
+    assert data["last_use_times"] == {}
+    assert data["cooldown_times"] == {}
+
+    restored = SimpleThrottleController.from_dict(data)
+    assert restored.default_cooldown_time == cooldown_time
+    assert restored.last_use_times == {}
+    assert restored.cooldown_times == {}
+
+
+def test_to_dict_json_compatible() -> None:
+    import json
+
+    cooldown_time = datetime.timedelta(seconds=2.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+    throttle.record_use_time("key1", datetime.datetime(2026, 6, 1, 0, 0, 0))
+
+    data = throttle.to_dict()
+    serialized = json.dumps(data)
+    deserialized = json.loads(serialized)
+    restored = SimpleThrottleController.from_dict(deserialized)
+
+    assert restored.default_cooldown_time == cooldown_time
+    assert restored.last_use_times == {
+        "key1": datetime.datetime(2026, 6, 1, 0, 0, 0),
+    }

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import time
 from dataclasses import dataclass, field
+from typing import Any
 
 from .protocol import Key, ThrottleController
 from .utils.interval import Interval, interval_to_timedelta
@@ -63,3 +64,40 @@ class SimpleThrottleController(ThrottleController):
     def clear(self) -> None:
         self.last_use_times.clear()
         self.cooldown_times.clear()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Export controller state as a JSON-compatible dict.
+
+        Keys are converted to strings. Restore with from_dict() after
+        a process restart to preserve throttling history across restarts.
+        """
+        return {
+            "default_cooldown_time": (
+                self.default_cooldown_time.total_seconds()
+            ),
+            "last_use_times": {
+                str(k): v.isoformat() for k, v in self.last_use_times.items()
+            },
+            "cooldown_times": {
+                str(k): v.total_seconds()
+                for k, v in self.cooldown_times.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SimpleThrottleController:
+        """Restore controller state from a dict produced by to_dict()."""
+        controller = cls(
+            default_cooldown_time=datetime.timedelta(
+                seconds=float(data["default_cooldown_time"]),
+            ),
+        )
+        controller.last_use_times = {
+            k: datetime.datetime.fromisoformat(v)
+            for k, v in data.get("last_use_times", {}).items()
+        }
+        controller.cooldown_times = {
+            k: datetime.timedelta(seconds=float(v))
+            for k, v in data.get("cooldown_times", {}).items()
+        }
+        return controller


### PR DESCRIPTION
## Summary

Add `to_dict()` and `from_dict()` methods to `SimpleThrottleController` to enable state serialization and restore across process restarts.

## Background

The controller's throttling state (`last_use_times`, `cooldown_times`) lives in memory and is lost when the process exits. For API rate-limiting use cases, a restart resets the cooldown history — the next process has no record of recent requests and may immediately send more, inadvertently exceeding the external API's rate limit window.

## Changes

- `SimpleThrottleController.to_dict()` — exports state as a JSON-compatible dict (datetimes as ISO 8601 strings, timedeltas as total seconds, keys as strings)
- `SimpleThrottleController.from_dict(data)` — restores state from a dict produced by `to_dict()`

### Usage example

```python
import json
from throttle_controller import SimpleThrottleController

# Save state before shutdown
throttle = SimpleThrottleController.create(default_cooldown_time=3.0)
with open("state.json", "w") as f:
    json.dump(throttle.to_dict(), f)

# Restore state on next startup
with open("state.json") as f:
    throttle = SimpleThrottleController.from_dict(json.load(f))
```

## Notes

- Keys are serialized as strings; non-string keys (e.g. integers) will be stored and restored as strings after a JSON round-trip.
- Three new tests cover the round-trip, empty-state, and JSON serialization cases.
