### PR TITLE
Reject negative cooldown intervals

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,6 +1,8 @@
 import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from throttle_controller import SimpleThrottleController
 
 
@@ -117,6 +119,34 @@ def test_set_cooldown_time() -> None:
     assert point2 == point1
     assert point3 - point2 == cooldown_time1
     assert point4 - point3 == cooldown_time2
+
+
+def test_create_rejects_negative_cooldown_time() -> None:
+    with pytest.raises(
+        ValueError,
+        match="cooldown interval must be non-negative",
+    ):
+        SimpleThrottleController.create(default_cooldown_time=-1)
+
+
+def test_direct_construction_rejects_negative_cooldown_time() -> None:
+    with pytest.raises(
+        ValueError,
+        match="cooldown interval must be non-negative",
+    ):
+        SimpleThrottleController(
+            default_cooldown_time=datetime.timedelta(seconds=-1),
+        )
+
+
+def test_set_cooldown_time_rejects_negative_cooldown_time() -> None:
+    throttle = SimpleThrottleController.create(default_cooldown_time=1)
+
+    with pytest.raises(
+        ValueError,
+        match="cooldown interval must be non-negative",
+    ):
+        throttle.set_cooldown_time("a", -1)
 
 
 def test_next_available_time() -> None:

--- a/tests/test_utils_interval.py
+++ b/tests/test_utils_interval.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from throttle_controller.utils.interval import interval_to_timedelta
 
 
@@ -10,3 +12,21 @@ def test_interval_to_timedelta() -> None:
     assert interval_to_timedelta(
         datetime.timedelta(seconds=1),
     ) == datetime.timedelta(seconds=1)
+
+
+@pytest.mark.parametrize(
+    "interval",
+    [
+        -1,
+        -1.0,
+        datetime.timedelta(seconds=-1),
+    ],
+)
+def test_interval_to_timedelta_rejects_negative_values(
+    interval: datetime.timedelta | float | int,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="cooldown interval must be non-negative",
+    ):
+        interval_to_timedelta(interval)

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -14,6 +14,11 @@ class SimpleThrottleController(ThrottleController):
     last_use_times: dict[Key, datetime.datetime] = field(default_factory=dict)
     cooldown_times: dict[Key, datetime.timedelta] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        self.default_cooldown_time = interval_to_timedelta(
+            self.default_cooldown_time,
+        )
+
     @classmethod
     def create(
         cls, *, default_cooldown_time: Interval,

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -6,7 +6,21 @@ Interval = datetime.timedelta | float | int
 
 
 def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:
+    if interval is None:
+        return datetime.timedelta(0)
+    return _ensure_non_negative(_interval_to_timedelta(interval))
+
+
+def _interval_to_timedelta(interval: Interval) -> datetime.timedelta:
     if isinstance(interval, datetime.timedelta):
         return interval
-    seconds = 0 if interval is None else interval
-    return datetime.timedelta(seconds=seconds)
+    return datetime.timedelta(seconds=interval)
+
+
+def _ensure_non_negative(
+    cooldown_time: datetime.timedelta,
+) -> datetime.timedelta:
+    if cooldown_time < datetime.timedelta(0):
+        msg = "cooldown interval must be non-negative"
+        raise ValueError(msg)
+    return cooldown_time


### PR DESCRIPTION
## Summary
- Reject negative cooldown intervals during interval conversion.
- Normalize direct `SimpleThrottleController` construction through the same validation path.
- Add regression coverage for `create()`, direct construction, `set_cooldown_time()`, and interval conversion.

## Dependency
- Stacked on #353 because it removes pre-existing wall-clock timing flakes in `tests/test_simple.py` that otherwise make local and CI test results nondeterministic.

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uvx vulture throttle_controller tests --min-confidence 100`
