### PR TITLE
feat: add DEBUG logging to SimpleThrottleController

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import datetime
+import logging
 from collections.abc import Callable
 from unittest.mock import patch
 
@@ -42,7 +43,9 @@ def manual_clock(start: datetime.datetime) -> Clock:
 
 def test_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
     cooldown_time = datetime.timedelta(seconds=1.0)
-    now, sleep, monotonic = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    now, sleep, monotonic = manual_clock(
+        datetime.datetime(2026, 1, 2, 3, 4, 5)
+    )
     monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
     monkeypatch.setattr("throttle_controller.simple.time.monotonic", monotonic)
     throttle = SimpleThrottleController(
@@ -77,7 +80,9 @@ def test_throttling(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_with_statement(monkeypatch: pytest.MonkeyPatch) -> None:
     cooldown_time = datetime.timedelta(seconds=1.0)
-    now, sleep, monotonic = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    now, sleep, monotonic = manual_clock(
+        datetime.datetime(2026, 1, 2, 3, 4, 5)
+    )
     monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
     monkeypatch.setattr("throttle_controller.simple.time.monotonic", monotonic)
     throttle = SimpleThrottleController.create(
@@ -100,7 +105,9 @@ def test_with_statement(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_set_cooldown_time(monkeypatch: pytest.MonkeyPatch) -> None:
     cooldown_time1 = datetime.timedelta(seconds=1.0)
     cooldown_time2 = datetime.timedelta(seconds=2.0)
-    now, sleep, monotonic = manual_clock(datetime.datetime(2026, 1, 2, 3, 4, 5))
+    now, sleep, monotonic = manual_clock(
+        datetime.datetime(2026, 1, 2, 3, 4, 5)
+    )
     monkeypatch.setattr("throttle_controller.simple.time.sleep", sleep)
     monkeypatch.setattr("throttle_controller.simple.time.monotonic", monotonic)
 
@@ -402,3 +409,28 @@ def test_wait_time_for_explicit_datetime_uses_wall_clock() -> None:
     throttle.record_use_time("a", base)
 
     assert throttle.wait_time_for("a") == datetime.timedelta(seconds=0.8)
+
+
+def test_record_use_time_emits_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    throttle = SimpleThrottleController(
+        default_cooldown_time=datetime.timedelta(seconds=1.0),
+    )
+    use_time = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    with caplog.at_level(logging.DEBUG, logger="throttle_controller.simple"):
+        throttle.record_use_time("api-key", use_time)
+    assert any("api-key" in r.message for r in caplog.records)
+
+
+def test_wait_if_needed_emits_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    throttle = SimpleThrottleController(
+        default_cooldown_time=datetime.timedelta(seconds=0.0),
+    )
+    use_time = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    throttle.record_use_time("api-key", use_time)
+    with caplog.at_level(logging.DEBUG, logger="throttle_controller.simple"):
+        throttle.wait_if_needed("api-key")
+    assert any("api-key" in r.message for r in caplog.records)

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import threading
 import time
 from collections.abc import Callable
@@ -9,6 +10,8 @@ from typing import Any
 
 from .protocol import Key, ThrottleController
 from .utils.interval import Interval, interval_to_timedelta
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -85,6 +88,7 @@ class SimpleThrottleController(ThrottleController):
             )
         self.last_use_times[key] = use_time
         self._last_monotonic_times.pop(key, None)
+        _logger.debug("recorded use of %r at %s", key, use_time.isoformat())
 
     def record_use_time_as_now(self, key: Key) -> None:
         """Record that *key* was used at the current time.
@@ -105,7 +109,9 @@ class SimpleThrottleController(ThrottleController):
             return datetime.timedelta(0)
         wait_time = self.wait_time_for(key)
         self._enforce_max_wait(wait_time)
-        time.sleep(wait_time.total_seconds())
+        seconds = wait_time.total_seconds()
+        _logger.debug("throttling %r: waiting %.3fs", key, seconds)
+        time.sleep(seconds)
         return wait_time
 
     def _enforce_max_wait(self, wait_time: datetime.timedelta) -> None:


### PR DESCRIPTION
## Summary

Add `logging.DEBUG` instrumentation to `SimpleThrottleController` so operators can observe throttle activity without modifying library code.

## Background

The library had no logging at all. When a throttle wait occurred or a use time was recorded, there was no way to observe this from the outside. Operators debugging rate-limit issues (unexpected delays, silent over-request behavior) had to add application-level instrumentation around every throttle call site.

## Changes

- Added `logging.getLogger(__name__)` to `throttle_controller/simple.py` (logger name: `throttle_controller.simple`)
- `record_use_time()` logs at DEBUG: key and the recorded timestamp
- `wait_if_needed()` logs at DEBUG: key and the wait duration in seconds

### Enabling log output

```python
import logging
logging.basicConfig(level=logging.DEBUG)
# or target the specific logger:
logging.getLogger("throttle_controller.simple").setLevel(logging.DEBUG)
```

## Notes

- Logs are emitted at `DEBUG` level only; no output unless the caller enables it.
- Two new tests verify that log records are emitted for `record_use_time` and `wait_if_needed` using pytest's `caplog` fixture.
