### PR TITLE
feat: return actual wait duration from wait_if_needed()

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import datetime
 from collections.abc import Callable
+from unittest.mock import patch
 
 import pytest
 
@@ -10,7 +11,7 @@ from throttle_controller import SimpleThrottleController
 Clock = tuple[Callable[[], datetime.datetime], Callable[[float], None]]
 
 
-def thread_error(callback: Callable[[], None]) -> BaseException | None:
+def thread_error(callback: Callable[[], object]) -> BaseException | None:
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
         future = executor.submit(callback)
         return future.exception(timeout=1.0)
@@ -276,3 +277,27 @@ def test_max_wait_none_allows_unlimited_wait() -> None:
     assert throttle.max_wait is None
     throttle.record_use_time_as_now("a")
     throttle.wait_if_needed("a")
+
+
+def test_wait_if_needed_returns_zero_for_new_key() -> None:
+    throttle = SimpleThrottleController(
+        default_cooldown_time=datetime.timedelta(seconds=1.0),
+    )
+    result = throttle.wait_if_needed("unseen")
+    assert result == datetime.timedelta(0)
+
+
+def test_wait_if_needed_returns_actual_wait_duration() -> None:
+    cooldown = datetime.timedelta(seconds=1.0)
+    base = datetime.datetime(2020, 1, 1)
+    fake_now = base + datetime.timedelta(seconds=0.2)
+    throttle = SimpleThrottleController(
+        default_cooldown_time=cooldown,
+        now=lambda: fake_now,
+    )
+    throttle.record_use_time("a", base)
+
+    with patch("throttle_controller.simple.time.sleep"):
+        result = throttle.wait_if_needed("a")
+
+    assert result == datetime.timedelta(seconds=0.8)

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -29,7 +29,7 @@ class ThrottleController(Protocol):  # pragma: no cover
         """Record that *key* was used at the current wall-clock time."""
         ...
 
-    def wait_if_needed(self, key: Key) -> None:
+    def wait_if_needed(self, key: Key) -> datetime.timedelta:
         """Block until *key* is no longer in cooldown."""
         ...
 

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -87,17 +87,18 @@ class SimpleThrottleController(ThrottleController):
         self._ensure_owner_thread()
         self.record_use_time(key, self.now())
 
-    def wait_if_needed(self, key: Key) -> None:
+    def wait_if_needed(self, key: Key) -> datetime.timedelta:
         """Sleep until *key*'s cooldown has elapsed.
 
         No-op when *key* has never been used.
         """
         self._ensure_owner_thread()
         if not self._has_ever_used(key):
-            return
+            return datetime.timedelta(0)
         wait_time = self.wait_time_for(key)
         self._enforce_max_wait(wait_time)
         time.sleep(wait_time.total_seconds())
+        return wait_time
 
     def _enforce_max_wait(self, wait_time: datetime.timedelta) -> None:
         if self.max_wait is not None and wait_time > self.max_wait:


### PR DESCRIPTION
## Summary

`wait_if_needed()` previously returned `None`, giving callers no way to observe how long they were actually blocked. This change returns a `datetime.timedelta` representing the actual sleep duration (zero if no wait occurred), making throttle latency available for tracing and metrics.

## Changes

- `throttle_controller/simple.py`: `wait_if_needed()` now returns `datetime.timedelta(0)` for unseen keys and the actual wait time after sleeping.
- `throttle_controller/protocol.py`: Updated `ThrottleController.wait_if_needed` return type from `None` to `datetime.timedelta`.
- `tests/test_simple.py`: Added two tests — one verifying zero is returned for a never-used key, and one verifying the exact wait duration is returned using a mock clock.

## Backwards Compatibility

Callers that discard the return value (the majority of usage) are unaffected. Callers that annotate the result as `None` will receive a type error and should update their annotation.

## Verification

- `uv run poe format` — clean
- `uv run poe check` (ruff + mypy) — clean
- `uv run pytest tests/` — all tests pass
- `uvx vulture throttle_controller tests --min-confidence 100` — 0 findings
