### PR TITLE
Add octocov coverage threshold

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,5 +1,6 @@
 # https://github.com/k1LoW/octocov?tab=readme-ov-file#configuration
 coverage:
+  acceptable: current >= 100%
   paths:
     - coverage.xml
 codeToTestRatio:


### PR DESCRIPTION
## Summary
- Add an octocov coverage gate that requires the current coverage to stay at or above 100%.
- Keep the existing `coverage.xml` path, code-to-test ratio, test execution time, diff, comment, and report settings unchanged.

## Dependency
- Stacked on #353 because it removes pre-existing wall-clock timing flakes in `tests/test_simple.py` that otherwise make local and CI test results nondeterministic.

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `uvx vulture throttle_controller tests --min-confidence 100`
