### PR TITLE
docs: add stability section with Alpha graduation conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ for _ in range(10):
         requests.get("http://example.com/path/to/api")
 ```
 
+## Stability
+
+This package is currently in **Alpha** (`Development Status :: 3 - Alpha`).
+
+- Breaking changes may occur between minor versions while in Alpha.
+- The package will be considered for Beta promotion when thread-safe and multi-process support is implemented.
+- A stable (1.0) release is planned after Beta validation.
+
 # Caution
 
 Currently this package supports only to use in single thread / single process use-cases.

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -10,7 +10,9 @@ class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime,
+        self,
+        key: Key,
+        use_time: datetime.datetime,
     ) -> None: ...
 
     def record_use_time_as_now(self, key: Key) -> None: ...

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -16,7 +16,9 @@ class SimpleThrottleController(ThrottleController):
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval,
+        cls,
+        *,
+        default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),


### PR DESCRIPTION
## Summary

Adds a **Stability** section to README documenting what the current Alpha status means and what conditions will trigger promotion to Beta or Stable.

**Why**: The `pyproject.toml` declares `Development Status :: 3 - Alpha` but there is no information anywhere in the repo about:
- What Alpha means in practice (breaking changes allowed)
- When the package will move to Beta/Stable

This makes it hard for consumers to decide whether to adopt the package and what compatibility guarantees to expect.

## Changes

- `README.md`: adds `## Stability` section explaining Alpha semantics and graduation conditions
- `throttle_controller/protocol.py`, `simple.py`: ruff auto-format (trailing comma expansion, no logic change)

## Verification

- `ruff format`: no further changes
- `ruff check`: all checks passed
- `mypy`: success (9 source files)
- `pytest`: 4/5 pass; 1 pre-existing timing-sensitive test (`test_throttling`) is flaky and unrelated to this change

## Trade-offs

- This is a minimal documentation addition (surface fix). A more complete approach would add a `CHANGELOG.md` with a formal versioning policy, but that goes beyond the scope of this finding.
