### PR TITLE
Remove unused typing-extensions runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "throttle-controller"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["typing-extensions"]
+dependencies = []
 description = "A simple throttling controller"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = { file = "LICENSE" }

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -10,7 +10,9 @@ class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime,
+        self,
+        key: Key,
+        use_time: datetime.datetime,
     ) -> None: ...
 
     def record_use_time_as_now(self, key: Key) -> None: ...

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -16,7 +16,9 @@ class SimpleThrottleController(ThrottleController):
 
     @classmethod
     def create(
-        cls, *, default_cooldown_time: Interval,
+        cls,
+        *,
+        default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-12T02:40:11.94241231Z"
+exclude-newer = "2026-05-31T00:29:37.16032Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -500,9 +500,6 @@ wheels = [
 [[package]]
 name = "throttle-controller"
 source = { editable = "." }
-dependencies = [
-    { name = "typing-extensions" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -515,7 +512,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Removes `typing-extensions` from the runtime dependencies in `pyproject.toml` — it is declared but never imported by the package.

**Why**: The package sets `requires-python = ">=3.10"`, and all types used in the codebase (`typing.Protocol`, `collections.abc.Generator`, `collections.abc.Hashable`) are available in the Python 3.10+ standard library without `typing-extensions`. Keeping an unused runtime dependency:
- adds an unnecessary install-time cost for all users
- increases the supply-chain attack surface
- can cause unexpected version conflicts in user environments

## Changes

- `pyproject.toml`: `dependencies = ["typing-extensions"]` → `dependencies = []`
- `uv.lock`: removes `typing-extensions` from locked dependencies
- `throttle_controller/protocol.py`, `simple.py`: ruff auto-format (trailing comma expansion, no logic change)

## Verification

- `ruff format`: no further changes after auto-format
- `ruff check`: all checks passed
- `mypy`: success (9 source files)
- `pytest`: 5/5 passed

## Trade-offs

- If a future Python version removes or changes a type that currently comes from the standard library, `typing-extensions` would need to be re-added. This is an unlikely scenario given Python's backward-compatibility guarantees.
