### PR TITLE
feat: add cooldown setter to throttle controller protocol

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from throttle_controller import SimpleThrottleController
+from throttle_controller import SimpleThrottleController, ThrottleController
 
 
 def _make_fake_clock(
@@ -147,6 +147,16 @@ def test_set_cooldown_time_rejects_negative_cooldown_time() -> None:
         match="cooldown interval must be non-negative",
     ):
         throttle.set_cooldown_time("a", -1)
+
+
+def test_protocol_exposes_set_cooldown_time() -> None:
+    throttle: ThrottleController = SimpleThrottleController.create(
+        default_cooldown_time=1.0,
+    )
+
+    throttle.set_cooldown_time("a", 2.0)
+
+    assert throttle.cooldown_time_for("a") == datetime.timedelta(seconds=2.0)
 
 
 def test_next_available_time() -> None:

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -3,11 +3,15 @@ import datetime
 from collections.abc import Generator, Hashable
 from typing import Protocol  # pragma: no cover
 
+from .utils.interval import Interval
+
 Key = Hashable
 
 
 class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
+
+    def set_cooldown_time(self, key: Key, cooldown_time: Interval) -> None: ...
 
     def record_use_time(
         self,


### PR DESCRIPTION
## Summary
- Add `set_cooldown_time()` to `ThrottleController`.
- Cover Protocol-typed setter usage in tests.

## Dependency
- Stacked on #353 for deterministic test timing.

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build` (passes with existing setuptools license deprecation warnings)
- `uvx vulture throttle_controller tests --min-confidence 80`
- `git diff --check`
