### PR TITLE
docs: document that use() records time before yield, test exception case

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -82,3 +82,24 @@ def test_next_available_time() -> None:
     point = datetime.datetime.now()
     throttle.record_use_time_as_now("a")
     assert throttle.next_available_time("a") > point
+
+
+def test_use_records_time_even_on_exception() -> None:
+    """A body that raises still consumes the cooldown slot.
+
+    ``use()`` records the use time *before* yielding control, so the
+    throttle state is updated regardless of whether the body succeeds.
+    """
+    cooldown_time = datetime.timedelta(seconds=1.0)
+    throttle = SimpleThrottleController(default_cooldown_time=cooldown_time)
+
+    assert throttle.next_available_time("a") == datetime.datetime.min
+
+    try:
+        with throttle.use("a"):
+            raise RuntimeError("simulated failure")
+    except RuntimeError:
+        pass
+
+    # The slot is consumed: next_available_time is in the future.
+    assert throttle.next_available_time("a") > datetime.datetime.min

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -10,7 +10,9 @@ class ThrottleController(Protocol):  # pragma: no cover
     def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime,
+        self,
+        key: Key,
+        use_time: datetime.datetime,
     ) -> None: ...
 
     def record_use_time_as_now(self, key: Key) -> None: ...
@@ -23,6 +25,17 @@ class ThrottleController(Protocol):  # pragma: no cover
 
     @contextlib.contextmanager
     def use(self, key: Key) -> Generator[None, None, None]:
+        """Apply throttle for the given key.
+
+        The use time is recorded *before* the body executes, so a body that
+        raises an exception still consumes a cooldown slot — the same as a
+        successful call.  This is intentional for API rate-limiting contexts
+        where a failed request still counts against the remote quota.
+
+        If your use-case requires the cooldown to be skipped on failure,
+        call ``wait_if_needed`` and ``record_use_time_as_now`` directly and
+        reset the recorded time in your exception handler.
+        """
         self.wait_if_needed(key)
         self.record_use_time_as_now(key)
         yield


### PR DESCRIPTION
## Summary

`ThrottleController.use()` calls `record_use_time_as_now()` *before* yielding, so a body that raises an exception still consumes a cooldown slot — exactly the same as a successful call.  This contract was implicit and undocumented, leaving callers to guess the intended behaviour.

- **Add a docstring to `use()`** that makes the pre-yield recording explicit and explains the rationale (failed API requests still count against the remote quota).  The docstring also shows how to opt out via the lower-level primitives when the caller needs a different policy.
- **Add `test_use_records_time_even_on_exception`** to verify and guard this behaviour.

## Motivation

The state machine for `ThrottleController` has two observable states — "never used" and "used at time T" — with no third "attempted but failed" state.  That design is sound for rate-limiting (where even a failed request is a request), but without documentation users cannot tell whether the behaviour is intentional or a bug.  This change makes the contract explicit so it can be reasoned about and tested.

## Changes

| File | Change |
|------|--------|
| `throttle_controller/protocol.py` | Docstring added to `use()` |
| `tests/test_simple.py` | New test `test_use_records_time_even_on_exception` |

## Verification

- `uv run pytest` — all 6 tests pass
- `uv run ruff format . && uv run ruff check .` — clean
- `uv run mypy throttle_controller tests/` — no issues