### PR TITLE
fix: raise ValueError for non-finite interval values (inf, nan)

### DIFF
--- a/tests/test_utils_interval.py
+++ b/tests/test_utils_interval.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from throttle_controller.utils.interval import IntervalSeconds, interval_to_timedelta
 
 
@@ -17,3 +19,15 @@ def test_interval_seconds_type_is_float_or_int() -> None:
     assert interval_to_timedelta(seconds) == datetime.timedelta(seconds=2.5)
     whole: IntervalSeconds = 3
     assert interval_to_timedelta(whole) == datetime.timedelta(seconds=3)
+
+
+def test_interval_to_timedelta_rejects_inf() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        interval_to_timedelta(float("inf"))
+    with pytest.raises(ValueError, match="finite"):
+        interval_to_timedelta(float("-inf"))
+
+
+def test_interval_to_timedelta_rejects_nan() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        interval_to_timedelta(float("nan"))

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -6,8 +6,17 @@ IntervalSeconds = float | int
 Interval = datetime.timedelta | IntervalSeconds
 
 
+def _seconds_to_timedelta(seconds: float | int) -> datetime.timedelta:
+    try:
+        return datetime.timedelta(seconds=seconds)
+    except (OverflowError, ValueError) as exc:
+        raise ValueError(
+            f"interval must be a finite number, got {seconds!r}",
+        ) from exc
+
+
 def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:
     if isinstance(interval, datetime.timedelta):
         return interval
     seconds = 0 if interval is None else interval
-    return datetime.timedelta(seconds=seconds)
+    return _seconds_to_timedelta(seconds)


### PR DESCRIPTION
## Summary

`interval_to_timedelta` accepted `float('inf')` and `float('nan')` without validation,
causing `OverflowError` or `ValueError` deep inside `datetime.timedelta` with a cryptic
message. Since the `Interval` type alias includes `float`, callers could reasonably pass
`float('inf')` expecting it to mean "wait forever", but the call would crash immediately.

## Changes

- `throttle_controller/utils/interval.py`: Extract `_seconds_to_timedelta` helper that
  wraps `datetime.timedelta(seconds=...)` in a `try/except`, converting
  `OverflowError` / `ValueError` into a clear `ValueError("interval must be a finite
  number, got …")`. This keeps the McCabe complexity of each function within the project
  limit (≤ 2).
- `tests/test_utils_interval.py`: Add regression tests for `inf`, `-inf`, and `nan`.
- `throttle_controller/protocol.py`, `throttle_controller/simple.py`: Formatter
  reformatted two function signatures to multi-line (no logic change).

## Validation

- `uv run poe format` — reformatted
- `uv run poe check` — all checks pass (ruff + mypy strict)
- `uv run pytest` — new tests pass; pre-existing wall-clock timing flakes in
  `test_throttling` / `test_set_cooldown_time` are unrelated to this change
- `uvx vulture throttle_controller tests --min-confidence 100` — no dead code

## Trade-offs

This is a surface fix: callers that pass `inf` or `nan` now receive an explicit
`ValueError` at the point of conversion rather than a confusing internal error.
A structural fix (e.g. a `PositiveDuration` wrapper type) would eliminate the class of
errors more broadly but is a larger scope change best revisited when multiple related
findings accumulate.