### PR TITLE
ci: remove duplicate coverage run from test workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -51,6 +51,3 @@ jobs:
 
       - name: Test
         run: uv run poe test
-
-      - name: Coverage
-        run: uv run poe coverage-xml


### PR DESCRIPTION
## Summary
- Remove the unused `Coverage` step from the Python test matrix workflow.
- Keep matrix test execution unchanged with `uv run poe test`.
- Leave coverage generation and reporting in the dedicated octocov workflow.

## Verification
- `actionlint .github/workflows/python-test.yml`
- `uv run poe check`
- `uv run poe test`
- `uv build`
- `uvx vulture throttle_controller tests --min-confidence 100`
- `git diff --check`

## Notes
- Local `uv run poe coverage-xml` still hits the existing timing-sensitive test flake on this machine; the unchanged octocov workflow remains the coverage gate for this PR.
