### PR TITLE
docs: add docstrings to all public API classes and functions

### DIFF
--- a/throttle_controller/__init__.py
+++ b/throttle_controller/__init__.py
@@ -1,3 +1,14 @@
+"""Throttle controller: rate-limiting primitives for Python applications.
+
+Usage::
+
+    from throttle_controller import SimpleThrottleController
+
+    controller = SimpleThrottleController.create(default_cooldown_time=1.0)
+    with controller.use("my-key"):
+        ...  # at most once per second per key
+"""
+
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
 from .protocol import ThrottleController

--- a/throttle_controller/protocol.py
+++ b/throttle_controller/protocol.py
@@ -7,22 +7,43 @@ Key = Hashable
 
 
 class ThrottleController(Protocol):  # pragma: no cover
-    def cooldown_time_for(self, key: Key) -> datetime.timedelta: ...
+    """Structural protocol for throttle controllers.
+
+    Implementations enforce a per-key cooldown: after each use the key is
+    blocked until ``cooldown_time_for(key)`` has elapsed.
+    """
+
+    def cooldown_time_for(self, key: Key) -> datetime.timedelta:
+        """Return the cooldown duration configured for *key*."""
+        ...
 
     def record_use_time(
-        self, key: Key, use_time: datetime.datetime,
-    ) -> None: ...
+        self,
+        key: Key,
+        use_time: datetime.datetime,
+    ) -> None:
+        """Record that *key* was used at *use_time*."""
+        ...
 
-    def record_use_time_as_now(self, key: Key) -> None: ...
+    def record_use_time_as_now(self, key: Key) -> None:
+        """Record that *key* was used at the current wall-clock time."""
+        ...
 
-    def wait_if_needed(self, key: Key) -> None: ...
+    def wait_if_needed(self, key: Key) -> None:
+        """Block until *key* is no longer in cooldown."""
+        ...
 
-    def wait_time_for(self, key: Key) -> datetime.timedelta: ...
+    def wait_time_for(self, key: Key) -> datetime.timedelta:
+        """Return the remaining cooldown duration for *key* (≥ 0)."""
+        ...
 
-    def next_available_time(self, key: Key) -> datetime.datetime: ...
+    def next_available_time(self, key: Key) -> datetime.datetime:
+        """Return the earliest datetime at which *key* may be used again."""
+        ...
 
     @contextlib.contextmanager
     def use(self, key: Key) -> Generator[None, None, None]:
+        """Context manager: wait for *key*'s cooldown, then record the use."""
         self.wait_if_needed(key)
         self.record_use_time_as_now(key)
         yield

--- a/throttle_controller/simple.py
+++ b/throttle_controller/simple.py
@@ -10,6 +10,17 @@ from .utils.interval import Interval, interval_to_timedelta
 
 @dataclass
 class SimpleThrottleController(ThrottleController):
+    """In-memory throttle controller with per-key cooldown tracking.
+
+    Tracks the last-use time for each key and enforces a minimum interval
+    (cooldown) between consecutive uses.  The default cooldown applies when
+    no per-key override has been set via :meth:`set_cooldown_time`.
+
+    Create via the factory method::
+
+        ctrl = SimpleThrottleController.create(default_cooldown_time=1.0)
+    """
+
     default_cooldown_time: datetime.timedelta
     last_use_times: dict[Key, datetime.datetime] = field(default_factory=dict)
     cooldown_times: dict[Key, datetime.timedelta] = field(default_factory=dict)
@@ -18,30 +29,52 @@ class SimpleThrottleController(ThrottleController):
     def create(
         cls, *, default_cooldown_time: Interval,
     ) -> SimpleThrottleController:
+        """Create a controller with the given default cooldown.
+
+        Args:
+            default_cooldown_time: Cooldown as a :class:`~datetime.timedelta`,
+                float seconds, or int seconds.
+        """
         return cls(
             default_cooldown_time=interval_to_timedelta(default_cooldown_time),
         )
 
     def cooldown_time_for(self, key: Key) -> datetime.timedelta:
+        """Return the effective cooldown duration for *key*.
+
+        Returns the per-key override if one has been set via
+        :meth:`set_cooldown_time`, otherwise the default cooldown.
+        """
         return self.cooldown_times.get(key, self.default_cooldown_time)
 
     def record_use_time(self, key: Key, use_time: datetime.datetime) -> None:
+        """Record that *key* was used at *use_time*."""
         self.last_use_times[key] = use_time
 
     def record_use_time_as_now(self, key: Key) -> None:
+        """Record that *key* was used at the current wall-clock time."""
         self.record_use_time(key, datetime.datetime.now())
 
     def wait_if_needed(self, key: Key) -> None:
+        """Sleep until *key*'s cooldown has elapsed.
+
+        No-op when *key* has never been used.
+        """
         if not self._has_ever_used(key):
             return
         wait_time = self.wait_time_for(key)
         time.sleep(wait_time.total_seconds())
 
     def wait_time_for(self, key: Key) -> datetime.timedelta:
+        """Return the remaining cooldown for *key*, or zero if ready."""
         wait_time = self.next_available_time(key) - datetime.datetime.now()
         return max(wait_time, datetime.timedelta(seconds=0))
 
     def next_available_time(self, key: Key) -> datetime.datetime:
+        """Return the earliest time at which *key* may be used again.
+
+        Returns :attr:`~datetime.datetime.min` when *key* has never been used.
+        """
         if not self._has_ever_used(key):
             return datetime.datetime.min
 
@@ -52,4 +85,11 @@ class SimpleThrottleController(ThrottleController):
         return key in self.last_use_times
 
     def set_cooldown_time(self, key: Key, cooldown_time: Interval) -> None:
+        """Set a per-key cooldown override.
+
+        Args:
+            key: The throttle key to configure.
+            cooldown_time: New cooldown as a :class:`~datetime.timedelta`,
+                float seconds, or int seconds.
+        """
         self.cooldown_times[key] = interval_to_timedelta(cooldown_time)

--- a/throttle_controller/utils/interval.py
+++ b/throttle_controller/utils/interval.py
@@ -1,3 +1,5 @@
+"""Utilities for converting interval values to :class:`~datetime.timedelta`."""
+
 from __future__ import annotations
 
 import datetime
@@ -6,6 +8,22 @@ Interval = datetime.timedelta | float | int
 
 
 def interval_to_timedelta(interval: Interval | None) -> datetime.timedelta:
+    """Convert an interval value to a :class:`~datetime.timedelta`.
+
+    Accepts a :class:`~datetime.timedelta` (returned as-is), a numeric number
+    of seconds (``int`` or ``float``), or ``None`` (treated as 0 seconds).
+    Raises :exc:`ValueError` for non-finite values such as ``inf`` or ``nan``.
+
+    Examples::
+
+        >>> import datetime
+        >>> interval_to_timedelta(1.5)
+        datetime.timedelta(seconds=1, microseconds=500000)
+        >>> interval_to_timedelta(datetime.timedelta(seconds=2))
+        datetime.timedelta(seconds=2)
+        >>> interval_to_timedelta(None)
+        datetime.timedelta(0)
+    """
     if isinstance(interval, datetime.timedelta):
         return interval
     seconds = 0 if interval is None else interval


### PR DESCRIPTION
## Summary

Add docstrings to all public API classes, methods, and functions. The `--doctest-modules` flag in `pyproject.toml` signals the intent to embed and run doctests, but no docstrings existed, making that flag a no-op.

**Changed files:**

- `throttle_controller/__init__.py` — module docstring with usage example
- `throttle_controller/protocol.py` — class and method docstrings for `ThrottleController`
- `throttle_controller/simple.py` — class and method docstrings for `SimpleThrottleController`
- `throttle_controller/utils/interval.py` — module docstring and a runnable doctest in `interval_to_timedelta`

## Verification

- `ruff check` and `mypy --strict` pass with no issues
- `pytest` (7 tests) passes
- `pytest --doctest-modules throttle_controller/` collects and passes 1 doctest from `interval_to_timedelta`

## Trade-offs

Docstrings for time-dependent methods (`wait_if_needed`, `wait_time_for`, `next_available_time`) describe behaviour in prose rather than embedding doctests, since those methods call `datetime.datetime.now()` and `time.sleep()` directly.
