### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,34 @@ This package is currently in **Alpha** (`Development Status :: 3 - Alpha`).
 Currently this package supports only to use in single thread / single process use-cases.
 Reusing the same controller instance from multiple threads raises `RuntimeError`.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same checks CI runs are also enforced locally via Git hooks
- CI (GitHub Actions) is kept completely unchanged — Actions remain free for public repos and serve as the authoritative quality gate
- Developers get faster feedback without waiting for CI

## Changes

- `lefthook.yml`: defines `pre-commit` (runs `uv run poe check`) and `pre-push` (runs `uv run poe check` and `uv run poe test`); unsets `GIT_*` environment variables before each job so nested/sibling repositories are not affected
- `README.md`: adds a `## Development` section describing how to install lefthook and what each hook does

## Verification

- `uv run poe check` passes locally (ruff + mypy clean)
- `uv run poe test` passes locally (17 tests)
- `lefthook install` followed by the commit triggered the pre-commit hook successfully
- `git push` triggered the pre-push hook (check + test) successfully

## Notes

- Requires `lefthook` on the developer's PATH (`brew install lefthook` or equivalent); it is not added as a Python dependency
- No CI workflow files were modified
