### PR TITLE
ci: migrate PyPI publish to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,6 +21,7 @@ jobs:
   deploy:
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -49,13 +50,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why

The PyPI publish workflow used long-lived API tokens stored as repository secrets (`PYPI_API_TOKEN`, `TEST_PYPI_API_TOKEN`). PyPI Trusted Publishers (OIDC) eliminate the need for stored secrets by using short-lived GitHub Actions OIDC tokens for authentication.

## What changed

- Added `id-token: write` permission to the `deploy` job so GitHub can issue an OIDC token.
- Removed `user: __token__` and `password:` parameters from both the Test PyPI and PyPI publish steps. `pypa/gh-action-pypi-publish` uses OIDC automatically when these are absent.

## Prerequisites before merging

The PyPI Trusted Publisher configuration must be added to the PyPI project settings before this workflow runs:

1. Go to https://pypi.org/manage/project/python-throttle-controller/settings/publishing/
2. Add a new Trusted Publisher with:
   - Publisher: GitHub Actions
   - Owner: `kitsuyui`
   - Repository: `python-throttle-controller`
   - Workflow: `pypi-publish.yml`
   - Environment: (leave blank)
3. Repeat for https://test.pypi.org/manage/project/python-throttle-controller/settings/publishing/ (Test PyPI)

Once the Trusted Publisher is configured, the `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets can be removed from repository settings.

## Verification

- `actionlint` passes with no findings.
- No existing callers are affected; the publish steps only run on release events.
