### PR TITLE
ci: add dependency vulnerability scanning with pip-audit

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -58,3 +58,20 @@ jobs:
 
       - name: Test
         run: uv run poe test
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Audit dependencies for known CVEs
+        run: |
+          uv export --no-emit-project -o /tmp/requirements.txt
+          uvx pip-audit -r /tmp/requirements.txt


### PR DESCRIPTION
## Summary

- Add an `audit` job to `.github/workflows/python-test.yml` that scans
  all locked dependencies for known CVEs using `uvx pip-audit`.

## Changes

- `.github/workflows/python-test.yml`: Add a new `audit` job that exports
  all locked dependencies via `uv export --no-emit-project` and checks them
  against the OSV Advisory Database using `uvx pip-audit`.

## Why

The existing CI pipeline had no step to detect known vulnerabilities in the
30+ packages fixed in `uv.lock`. A package receiving a new CVE assignment
after the lockfile was last updated would pass CI undetected.

`uv export --no-emit-project` converts the lockfile to a requirements list
without installing anything. `uvx pip-audit` then queries the OSV Advisory
Database ephemerally — no permanent `pip-audit` dependency is added to the
project.

## Verification

- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)`
- Workflow linted with `actionlint`: no findings
- Collateral check: clean (no `gha-inline-script` / `version-shrink` / `too-many-files`)

## Trade-offs

`uv export --no-emit-project` exports all packages from `uv.lock` including
dev dependencies. This is intentional: dev dependencies that run during CI
(pytest, mypy, ruff) are also part of the build environment and should be
scanned. If only runtime dependencies are required in future, `--only-group
default` can be added.